### PR TITLE
vec3.h: spelling error in documentation

### DIFF
--- a/src/ccd/vec3.h
+++ b/src/ccd/vec3.h
@@ -182,7 +182,7 @@ _ccd_inline void ccdVec3Cross(ccd_vec3_t *d, const ccd_vec3_t *a, const ccd_vec3
 /**
  * Returns distance^2 of point P to segment ab.
  * If witness is non-NULL it is filled with coordinates of point from which
- * was computaed distance to point P.
+ * was computed distance to point P.
  */
 ccd_real_t ccdVec3PointSegmentDist2(const ccd_vec3_t *P,
                                 const ccd_vec3_t *a, const ccd_vec3_t *b,


### PR DESCRIPTION
computaed -> computed