### PR TITLE
Regarding issue #17: ccdGJKPenetration does not calculate exact contact location on a large box. 

### DIFF
--- a/src/testsuites/boxbox.c
+++ b/src/testsuites/boxbox.c
@@ -464,3 +464,35 @@ TEST(boxboxPenetration)
     recPen(depth, &dir, &pos, stdout, "Pen 8");
     //TOSVT();
 }
+
+TEST(boxboxPenetration2)
+{
+
+    ccd_t ccd;
+    CCD_BOX(box1);
+    CCD_BOX(box2);
+    int res;
+    ccd_real_t depth;
+    ccd_vec3_t dir, pos;
+
+    fprintf(stderr, "\n\n\n---- boxboxPenetration ----\n\n\n");
+
+    box1.x = 20;
+    box1.y = 0.1;
+    box1.z = 20;
+    box2.x = 0.2;
+    box2.y = 0.15;
+    box2.z = 0.2;
+
+    CCD_INIT(&ccd);
+    ccd.support1 = ccdSupport;
+    ccd.support2 = ccdSupport;
+
+    ccdVec3Set(&box2.pos, 0, 0.1, 0.);
+    res = ccdGJKPenetration(&box1, &box2, &ccd, &depth, &dir, &pos);
+    assertTrue(res == 0);
+    recPen(depth, &dir, &pos, stdout, "Pen largeBox");
+    assertTrue(-0.2 < pos.v[0] && pos.v[0] <0.2);
+    //TOSVT();
+
+}

--- a/src/testsuites/boxbox.h
+++ b/src/testsuites/boxbox.h
@@ -14,6 +14,7 @@ TEST(boxboxRot);
 
 TEST(boxboxSeparate);
 TEST(boxboxPenetration);
+TEST(boxboxPenetration2);
 
 TEST_SUITE(TSBoxBox) {
     TEST_ADD(boxboxSetUp),
@@ -24,6 +25,7 @@ TEST_SUITE(TSBoxBox) {
     TEST_ADD(boxboxRot),
     TEST_ADD(boxboxSeparate),
     TEST_ADD(boxboxPenetration),
+	TEST_ADD(boxboxPenetration2),
 
     TEST_ADD(boxboxTearDown),
     TEST_SUITE_CLOSURE

--- a/src/testsuites/mpr_boxbox.c
+++ b/src/testsuites/mpr_boxbox.c
@@ -500,3 +500,36 @@ TEST(mprBoxboxPenetration)
     recPen(depth, &dir, &pos, stdout, "Pen 10");
     //TOSVT();
 }
+TEST(mprBoxboxPenetration2)
+{
+
+    ccd_t ccd;
+    CCD_BOX(box1);
+    CCD_BOX(box2);
+    int res;
+    ccd_real_t depth;
+    ccd_vec3_t dir, pos;
+
+    fprintf(stderr, "\n\n\n---- boxboxPenetration ----\n\n\n");
+
+    box1.x = 20;
+    box1.y = 0.1;
+    box1.z = 20;
+    box2.x = 0.2;
+    box2.y = 0.15;
+    box2.z = 0.2;
+
+    CCD_INIT(&ccd);
+    ccd.support1 = ccdSupport;
+    ccd.support2 = ccdSupport;
+    ccd.center1 = ccdObjCenter;
+    ccd.center2 = ccdObjCenter;
+
+    ccdVec3Set(&box2.pos, 0, 0.1, 0.);
+    res = ccdMPRPenetration(&box1, &box2, &ccd, &depth, &dir, &pos);
+    assertTrue(res == 0);
+    recPen(depth, &dir, &pos, stdout, "Pen largeBox mpr");
+    assertTrue(-0.2 < pos.v[0] && pos.v[0] <0.2);
+    //TOSVT();
+
+}

--- a/src/testsuites/mpr_boxbox.h
+++ b/src/testsuites/mpr_boxbox.h
@@ -11,6 +11,7 @@ TEST(mprBoxboxRot);
 
 TEST(mprBoxboxSeparate);
 TEST(mprBoxboxPenetration);
+TEST(mprBoxboxPenetration2);
 
 TEST_SUITE(TSMPRBoxBox) {
     TEST_ADD(mprBoxboxAlignedX),
@@ -19,7 +20,7 @@ TEST_SUITE(TSMPRBoxBox) {
     TEST_ADD(mprBoxboxRot),
     TEST_ADD(mprBoxboxSeparate),
     TEST_ADD(mprBoxboxPenetration),
-
+	TEST_ADD(mprBoxboxPenetration2),
     TEST_SUITE_CLOSURE
 };
 


### PR DESCRIPTION
I created a test routine that fails for ccdGJKpenetration but not for ccdMPRpenetration.
