### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The only exception are testsuites that are built on top of CU
 testing depends on it and libccd library itself can be distributed without it.
 
 
-##License
+## License
 
 libccd is licensed under OSI-approved 3-clause BSD License, text of license
 is distributed along with source code in BSD-LICENSE file.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
