### PR TITLE
Add missing exports for Windows DLL

### DIFF
--- a/src/ccd/vec3.h
+++ b/src/ccd/vec3.h
@@ -93,13 +93,13 @@ typedef struct _ccd_vec3_t ccd_vec3_t;
 /**
  * Holds origin (0,0,0) - this variable is meant to be read-only!
  */
-extern ccd_vec3_t *ccd_vec3_origin;
+_ccd_export extern ccd_vec3_t *ccd_vec3_origin;
 
 /**
  * Array of points uniformly distributed on unit sphere.
  */
-extern ccd_vec3_t *ccd_points_on_sphere;
-extern size_t ccd_points_on_sphere_len;
+_ccd_export extern ccd_vec3_t *ccd_points_on_sphere;
+_ccd_export extern size_t ccd_points_on_sphere_len;
 
 /** Returns sign of value. */
 _ccd_inline int ccdSign(ccd_real_t val);

--- a/src/polytope.h
+++ b/src/polytope.h
@@ -101,8 +101,8 @@ struct _ccd_pt_t {
 typedef struct _ccd_pt_t ccd_pt_t;
 
 
-void ccdPtInit(ccd_pt_t *pt);
-void ccdPtDestroy(ccd_pt_t *pt);
+_ccd_export void ccdPtInit(ccd_pt_t *pt);
+_ccd_export void ccdPtDestroy(ccd_pt_t *pt);
 
 /**
  * Returns vertices surrounding given triangle face.
@@ -134,20 +134,20 @@ _ccd_inline void ccdPtEdgeFaces(const ccd_pt_edge_t *e,
 /**
  * Adds vertex to polytope and returns pointer to newly created vertex.
  */
-ccd_pt_vertex_t *ccdPtAddVertex(ccd_pt_t *pt, const ccd_support_t *v);
+_ccd_export ccd_pt_vertex_t *ccdPtAddVertex(ccd_pt_t *pt, const ccd_support_t *v);
 _ccd_inline ccd_pt_vertex_t *ccdPtAddVertexCoords(ccd_pt_t *pt,
                                                   ccd_real_t x, ccd_real_t y, ccd_real_t z);
 
 /**
  * Adds edge to polytope.
  */
-ccd_pt_edge_t *ccdPtAddEdge(ccd_pt_t *pt, ccd_pt_vertex_t *v1,
+_ccd_export ccd_pt_edge_t *ccdPtAddEdge(ccd_pt_t *pt, ccd_pt_vertex_t *v1,
                                           ccd_pt_vertex_t *v2);
 
 /**
  * Adds face to polytope.
  */
-ccd_pt_face_t *ccdPtAddFace(ccd_pt_t *pt, ccd_pt_edge_t *e1,
+_ccd_export ccd_pt_face_t *ccdPtAddFace(ccd_pt_t *pt, ccd_pt_edge_t *e1,
                                           ccd_pt_edge_t *e2,
                                           ccd_pt_edge_t *e3);
 
@@ -168,7 +168,7 @@ void ccdPtRecomputeDistances(ccd_pt_t *pt);
 /**
  * Returns nearest element to origin.
  */
-ccd_pt_el_t *ccdPtNearest(ccd_pt_t *pt);
+_ccd_export ccd_pt_el_t *ccdPtNearest(ccd_pt_t *pt);
 
 
 void ccdPtDumpSVT(ccd_pt_t *pt, const char *fn);

--- a/src/support.h
+++ b/src/support.h
@@ -37,7 +37,7 @@ _ccd_inline void ccdSupportCopy(ccd_support_t *, const ccd_support_t *s);
  * Computes support point of obj1 and obj2 in direction dir.
  * Support point is returned via supp.
  */
-void __ccdSupport(const void *obj1, const void *obj2,
+_ccd_export void __ccdSupport(const void *obj1, const void *obj2,
                   const ccd_vec3_t *dir, const ccd_t *ccd,
                   ccd_support_t *supp);
 


### PR DESCRIPTION
Adds missing `_ccd_export` definitions to functions that lead to _unresolved external symbol_ when compiling a shared library on Windows and linking to it. Seems also related to https://github.com/flexible-collision-library/fcl/issues/183.