### PR TITLE
C visibility support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,13 @@ option(BUILD_SHARED_LIBS "Build libccd as a shared library" ON)
 option(ENABLE_DOUBLE_PRECISION
   "Enable double precision computations instead of single precision" OFF)
 
+# Option for some bundle-like build system in order not to expose
+# any FCL binary symbols in their public ABI
+option(CCD_HIDE_ALL_SYMBOLS "Hide all binary symbols" OFF)
+if (CCD_HIDE_ALL_SYMBOLS)
+  add_definitions("-DCCD_STATIC_DEFINE")
+endif()
+
 # set the default build type
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
 endif()
 
-project(libccd C)
+# Can not explicitly declared the software as C in project command due to bug:
+# https://gitlab.kitware.com/cmake/cmake/issues/16967
+project(libccd)
 
 set(CCD_VERSION_MAJOR 2)
 set(CCD_VERSION_MINOR 0)
@@ -15,6 +17,7 @@ set(CCD_SOVERSION 2)
 # Include GNUInstallDirs to get canonical paths
 include(GNUInstallDirs)
 include(CTest)
+include(GenerateExportHeader)
 
 option(BUILD_DOCUMENTATION "Build the documentation" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CCD_SOVERSION 2)
 # Include GNUInstallDirs to get canonical paths
 include(GNUInstallDirs)
 include(CTest)
-include(GenerateExportHeader)
 
 option(BUILD_DOCUMENTATION "Build the documentation" OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ if(UNIX)
   endif()
 endif()
 
-if(NOT WIN32 AND BUILD_TESTING)
+if(NOT WIN32 AND BUILD_TESTING AND NOT CCD_HIDE_ALL_SYMBOLS)
   add_subdirectory(testsuites)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,9 +88,6 @@ endif()
 
 get_property(type TARGET ccd PROPERTY TYPE)
 
-# Need to include directory to find export file
-include_directories(${PROJECT_BINARY_DIR})
-
 generate_export_header(ccd)
-install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}_export.h
+install(FILES ${PROJECT_BINARY_DIR}/src/ccd_export.h
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,25 @@ install(TARGETS ccd
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 install(EXPORT ccd-targets DESTINATION "${CMAKE_INSTALL_LIBDIR}/ccd")
 
+macro (check_compiler_visibility)
+  include (CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-fvisibility=hidden COMPILER_SUPPORTS_VISIBILITY)
+endmacro()
+
+if(UNIX)
+  check_compiler_visibility()
+  if (COMPILER_SUPPORTS_VISIBILITY)
+    set_target_properties(ccd
+         PROPERTIES COMPILE_FLAGS "-fvisibility=hidden")
+  endif()
+endif()
+
 if(NOT WIN32 AND BUILD_TESTING)
   add_subdirectory(testsuites)
 endif()
+
+get_property(type TARGET ccd PROPERTY TYPE)
+
+generate_export_header(ccd)
+install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}_export.h
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ configure_file(ccd/config.h.cmake.in ccd/config.h)
 set(CCD_INCLUDES
   ccd/ccd.h
   ccd/compiler.h
+  ccd/ccd_export.h
   ccd/quat.h
   ccd/vec3.h
   "${CMAKE_CURRENT_BINARY_DIR}/ccd/config.h")
@@ -85,9 +86,3 @@ endif()
 if(NOT WIN32 AND BUILD_TESTING AND NOT CCD_HIDE_ALL_SYMBOLS)
   add_subdirectory(testsuites)
 endif()
-
-get_property(type TARGET ccd PROPERTY TYPE)
-
-generate_export_header(ccd)
-install(FILES ${PROJECT_BINARY_DIR}/src/ccd_export.h
-   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,9 @@ endif()
 
 get_property(type TARGET ccd PROPERTY TYPE)
 
+# Need to include directory to find export file
+include_directories(${PROJECT_BINARY_DIR})
+
 generate_export_header(ccd)
 install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}_export.h
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@
 
 -include Makefile.include
 
-CFLAGS += -I.
+CFLAGS += -I. -fvisibility=hidden
 
 TARGETS = libccd.a
 OBJS = ccd.o mpr.o support.o vec3.o polytope.o

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,6 +6,7 @@ libccd_la_SOURCES = alloc.h \
 		ccd/compiler.h \
 		dbg.h \
 		ccd.c ccd/ccd.h \
+		ccd/ccd_export.h \
 		list.h \
 		polytope.c polytope.h \
 		ccd/quat.h \
@@ -14,3 +15,4 @@ libccd_la_SOURCES = alloc.h \
 		vec3.c ccd/vec3.h \
         mpr.c
 
+libccd_la_CFLAGS = -fvisibility=hidden

--- a/src/ccd/ccd.h
+++ b/src/ccd/ccd.h
@@ -19,6 +19,7 @@
 #define __CCD_H__
 
 #include <ccd/vec3.h>
+#include <ccd_export.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,7 +73,7 @@ typedef struct _ccd_t ccd_t;
 /**
  * Default first direction.
  */
-_ccd_export void ccdFirstDirDefault(const void *o1, const void *o2,
+CCD_EXPORT void ccdFirstDirDefault(const void *o1, const void *o2,
                                     ccd_vec3_t *dir);
 
 #define CCD_INIT(ccd) \
@@ -93,7 +94,7 @@ _ccd_export void ccdFirstDirDefault(const void *o1, const void *o2,
 /**
  * Returns true if two given objects interest.
  */
-_ccd_export int ccdGJKIntersect(const void *obj1, const void *obj2,
+CCD_EXPORT int ccdGJKIntersect(const void *obj1, const void *obj2,
                                 const ccd_t *ccd);
 
 /**
@@ -104,7 +105,7 @@ _ccd_export int ccdGJKIntersect(const void *obj1, const void *obj2,
  * vector. If obj1 and obj2 don't intersect -1 is returned.
  * If memory allocation fails -2 is returned.
  */
-_ccd_export int ccdGJKSeparate(const void *obj1, const void *obj2,
+CCD_EXPORT int ccdGJKSeparate(const void *obj1, const void *obj2,
                                const ccd_t *ccd, ccd_vec3_t *sep);
 
 /**
@@ -121,14 +122,14 @@ _ccd_export int ccdGJKSeparate(const void *obj1, const void *obj2,
  * If obj1 and obj2 don't intersect -1 is returned.
  * If memory allocation fails -2 is returned.
  */
-_ccd_export int ccdGJKPenetration(const void *obj1, const void *obj2,
+CCD_EXPORT int ccdGJKPenetration(const void *obj1, const void *obj2,
                                   const ccd_t *ccd, ccd_real_t *depth,
                                   ccd_vec3_t *dir, ccd_vec3_t *pos);
 
 /**
  * Returns true if two given objects intersect - MPR algorithm is used.
  */
-_ccd_export int ccdMPRIntersect(const void *obj1, const void *obj2,
+CCD_EXPORT int ccdMPRIntersect(const void *obj1, const void *obj2,
                                 const ccd_t *ccd);
 
 /**
@@ -143,7 +144,7 @@ _ccd_export int ccdMPRIntersect(const void *obj1, const void *obj2,
  *
  * Returns 0 if obj1 and obj2 intersect, otherwise -1 is returned.
  */
-_ccd_export int ccdMPRPenetration(const void *obj1, const void *obj2,
+CCD_EXPORT int ccdMPRPenetration(const void *obj1, const void *obj2,
                                   const ccd_t *ccd, ccd_real_t *depth,
                                   ccd_vec3_t *dir, ccd_vec3_t *pos);
 

--- a/src/ccd/ccd.h
+++ b/src/ccd/ccd.h
@@ -19,7 +19,6 @@
 #define __CCD_H__
 
 #include <ccd/vec3.h>
-#include <ccd_export.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ccd/ccd_export.h
+++ b/src/ccd/ccd_export.h
@@ -1,0 +1,41 @@
+
+#ifndef CCD_EXPORT_H
+#define CCD_EXPORT_H
+
+#ifdef CCD_STATIC_DEFINE
+#  define CCD_EXPORT
+#  define CCD_NO_EXPORT
+#else
+#  ifndef CCD_EXPORT
+#    ifdef ccd_EXPORTS
+        /* We are building this library */
+#      define CCD_EXPORT __attribute__((visibility("default")))
+#    else
+        /* We are using this library */
+#      define CCD_EXPORT __attribute__((visibility("default")))
+#    endif
+#  endif
+
+#  ifndef CCD_NO_EXPORT
+#    define CCD_NO_EXPORT __attribute__((visibility("hidden")))
+#  endif
+#endif
+
+#ifndef CCD_DEPRECATED
+#  define CCD_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+
+#ifndef CCD_DEPRECATED_EXPORT
+#  define CCD_DEPRECATED_EXPORT CCD_EXPORT CCD_DEPRECATED
+#endif
+
+#ifndef CCD_DEPRECATED_NO_EXPORT
+#  define CCD_DEPRECATED_NO_EXPORT CCD_NO_EXPORT CCD_DEPRECATED
+#endif
+
+#define DEFINE_NO_DEPRECATED 0
+#if DEFINE_NO_DEPRECATED
+# define CCD_NO_DEPRECATED
+#endif
+
+#endif

--- a/src/ccd/ccd_export.h
+++ b/src/ccd/ccd_export.h
@@ -1,41 +1,26 @@
-
 #ifndef CCD_EXPORT_H
 #define CCD_EXPORT_H
 
 #ifdef CCD_STATIC_DEFINE
 #  define CCD_EXPORT
-#  define CCD_NO_EXPORT
 #else
-#  ifndef CCD_EXPORT
+#  ifdef _MSC_VER
 #    ifdef ccd_EXPORTS
-        /* We are building this library */
-#      define CCD_EXPORT __attribute__((visibility("default")))
-#    else
-        /* We are using this library */
-#      define CCD_EXPORT __attribute__((visibility("default")))
+#      define _ccd_export __declspec(dllexport)
+#   else /* ccd_EXPORTS */
+#     define _ccd_export __declspec(dllimport)
+#   endif /* ccd_EXPORTS */
+#  else
+#    ifndef CCD_EXPORT
+#      ifdef ccd_EXPORTS
+          /* We are building this library */
+#        define CCD_EXPORT __attribute__((visibility("default")))
+#      else
+          /* We are using this library */
+#        define CCD_EXPORT __attribute__((visibility("default")))
+#      endif
 #    endif
 #  endif
-
-#  ifndef CCD_NO_EXPORT
-#    define CCD_NO_EXPORT __attribute__((visibility("hidden")))
-#  endif
-#endif
-
-#ifndef CCD_DEPRECATED
-#  define CCD_DEPRECATED __attribute__ ((__deprecated__))
-#endif
-
-#ifndef CCD_DEPRECATED_EXPORT
-#  define CCD_DEPRECATED_EXPORT CCD_EXPORT CCD_DEPRECATED
-#endif
-
-#ifndef CCD_DEPRECATED_NO_EXPORT
-#  define CCD_DEPRECATED_NO_EXPORT CCD_NO_EXPORT CCD_DEPRECATED
-#endif
-
-#define DEFINE_NO_DEPRECATED 0
-#if DEFINE_NO_DEPRECATED
-# define CCD_NO_DEPRECATED
 #endif
 
 #endif

--- a/src/ccd/compiler.h
+++ b/src/ccd/compiler.h
@@ -25,21 +25,6 @@
 #define ccd_container_of(ptr, type, member) \
     (type *)( (char *)ptr - ccd_offsetof(type, member))
 
-
-/**
- * Marks exported function.
- */
-#ifdef _WIN32
-# ifdef ccd_EXPORTS
-#   define _ccd_export __declspec(dllexport)
-# else /* ccd_EXPORTS */
-#   define _ccd_export __declspec(dllimport)
-# endif /* ccd_EXPORTS */
-#else /* _WIN32 */
-# define _ccd_export
-#endif /* _WIN32 */
-
-
 /**
  * Marks inline function.
  */

--- a/src/ccd/vec3.h
+++ b/src/ccd/vec3.h
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <ccd/compiler.h>
 #include <ccd/config.h>
-#include "ccd_export.h"
+#include <ccd/ccd_export.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ccd/vec3.h
+++ b/src/ccd/vec3.h
@@ -94,13 +94,13 @@ typedef struct _ccd_vec3_t ccd_vec3_t;
 /**
  * Holds origin (0,0,0) - this variable is meant to be read-only!
  */
-extern ccd_vec3_t *ccd_vec3_origin;
+CCD_EXPORT extern ccd_vec3_t *ccd_vec3_origin;
 
 /**
  * Array of points uniformly distributed on unit sphere.
  */
-extern ccd_vec3_t *ccd_points_on_sphere;
-extern size_t ccd_points_on_sphere_len;
+CCD_EXPORT extern ccd_vec3_t *ccd_points_on_sphere;
+CCD_EXPORT extern size_t ccd_points_on_sphere_len;
 
 /** Returns sign of value. */
 _ccd_inline int ccdSign(ccd_real_t val);

--- a/src/ccd/vec3.h
+++ b/src/ccd/vec3.h
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <ccd/compiler.h>
 #include <ccd/config.h>
+#include <ccd_export.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -184,7 +185,7 @@ _ccd_inline void ccdVec3Cross(ccd_vec3_t *d, const ccd_vec3_t *a, const ccd_vec3
  * If witness is non-NULL it is filled with coordinates of point from which
  * was computed distance to point P.
  */
-_ccd_export ccd_real_t ccdVec3PointSegmentDist2(const ccd_vec3_t *P,
+CCD_EXPORT ccd_real_t ccdVec3PointSegmentDist2(const ccd_vec3_t *P,
                                                 const ccd_vec3_t *a,
                                                 const ccd_vec3_t *b,
                                                 ccd_vec3_t *witness);
@@ -194,7 +195,7 @@ _ccd_export ccd_real_t ccdVec3PointSegmentDist2(const ccd_vec3_t *P,
  * If witness vector is provided it is filled with coordinates of point
  * from which was computed distance to point P.
  */
-_ccd_export ccd_real_t ccdVec3PointTriDist2(const ccd_vec3_t *P,
+CCD_EXPORT ccd_real_t ccdVec3PointTriDist2(const ccd_vec3_t *P,
                                             const ccd_vec3_t *a,
                                             const ccd_vec3_t *b,
                                             const ccd_vec3_t *c,

--- a/src/ccd/vec3.h
+++ b/src/ccd/vec3.h
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <ccd/compiler.h>
 #include <ccd/config.h>
-#include <ccd_export.h>
+#include "ccd_export.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/polytope.h
+++ b/src/polytope.h
@@ -135,7 +135,7 @@ _ccd_inline void ccdPtEdgeFaces(const ccd_pt_edge_t *e,
  * Adds vertex to polytope and returns pointer to newly created vertex.
  */
 CCD_EXPORT ccd_pt_vertex_t *ccdPtAddVertex(ccd_pt_t *pt, const ccd_support_t *v);
-CCD_EXPORT _ccd_inline ccd_pt_vertex_t *ccdPtAddVertexCoords(ccd_pt_t *pt,
+_ccd_inline ccd_pt_vertex_t *ccdPtAddVertexCoords(ccd_pt_t *pt,
                                                   ccd_real_t x, ccd_real_t y, ccd_real_t z);
 
 /**
@@ -155,9 +155,9 @@ CCD_EXPORT ccd_pt_face_t *ccdPtAddFace(ccd_pt_t *pt, ccd_pt_edge_t *e1,
  * Deletes vertex from polytope.
  * Returns 0 on success, -1 otherwise.
  */
-CCD_EXPORT _ccd_inline int ccdPtDelVertex(ccd_pt_t *pt, ccd_pt_vertex_t *);
-CCD_EXPORT _ccd_inline int ccdPtDelEdge(ccd_pt_t *pt, ccd_pt_edge_t *);
-CCD_EXPORT _ccd_inline int ccdPtDelFace(ccd_pt_t *pt, ccd_pt_face_t *);
+_ccd_inline int ccdPtDelVertex(ccd_pt_t *pt, ccd_pt_vertex_t *);
+_ccd_inline int ccdPtDelEdge(ccd_pt_t *pt, ccd_pt_edge_t *);
+_ccd_inline int ccdPtDelFace(ccd_pt_t *pt, ccd_pt_face_t *);
 
 
 /**

--- a/src/polytope.h
+++ b/src/polytope.h
@@ -101,8 +101,8 @@ struct _ccd_pt_t {
 typedef struct _ccd_pt_t ccd_pt_t;
 
 
-void ccdPtInit(ccd_pt_t *pt);
-void ccdPtDestroy(ccd_pt_t *pt);
+CCD_EXPORT void ccdPtInit(ccd_pt_t *pt);
+CCD_EXPORT void ccdPtDestroy(ccd_pt_t *pt);
 
 /**
  * Returns vertices surrounding given triangle face.
@@ -134,20 +134,20 @@ _ccd_inline void ccdPtEdgeFaces(const ccd_pt_edge_t *e,
 /**
  * Adds vertex to polytope and returns pointer to newly created vertex.
  */
-ccd_pt_vertex_t *ccdPtAddVertex(ccd_pt_t *pt, const ccd_support_t *v);
-_ccd_inline ccd_pt_vertex_t *ccdPtAddVertexCoords(ccd_pt_t *pt,
+CCD_EXPORT ccd_pt_vertex_t *ccdPtAddVertex(ccd_pt_t *pt, const ccd_support_t *v);
+CCD_EXPORT _ccd_inline ccd_pt_vertex_t *ccdPtAddVertexCoords(ccd_pt_t *pt,
                                                   ccd_real_t x, ccd_real_t y, ccd_real_t z);
 
 /**
  * Adds edge to polytope.
  */
-ccd_pt_edge_t *ccdPtAddEdge(ccd_pt_t *pt, ccd_pt_vertex_t *v1,
+CCD_EXPORT ccd_pt_edge_t *ccdPtAddEdge(ccd_pt_t *pt, ccd_pt_vertex_t *v1,
                                           ccd_pt_vertex_t *v2);
 
 /**
  * Adds face to polytope.
  */
-ccd_pt_face_t *ccdPtAddFace(ccd_pt_t *pt, ccd_pt_edge_t *e1,
+CCD_EXPORT ccd_pt_face_t *ccdPtAddFace(ccd_pt_t *pt, ccd_pt_edge_t *e1,
                                           ccd_pt_edge_t *e2,
                                           ccd_pt_edge_t *e3);
 
@@ -155,24 +155,24 @@ ccd_pt_face_t *ccdPtAddFace(ccd_pt_t *pt, ccd_pt_edge_t *e1,
  * Deletes vertex from polytope.
  * Returns 0 on success, -1 otherwise.
  */
-_ccd_inline int ccdPtDelVertex(ccd_pt_t *pt, ccd_pt_vertex_t *);
-_ccd_inline int ccdPtDelEdge(ccd_pt_t *pt, ccd_pt_edge_t *);
-_ccd_inline int ccdPtDelFace(ccd_pt_t *pt, ccd_pt_face_t *);
+CCD_EXPORT _ccd_inline int ccdPtDelVertex(ccd_pt_t *pt, ccd_pt_vertex_t *);
+CCD_EXPORT _ccd_inline int ccdPtDelEdge(ccd_pt_t *pt, ccd_pt_edge_t *);
+CCD_EXPORT _ccd_inline int ccdPtDelFace(ccd_pt_t *pt, ccd_pt_face_t *);
 
 
 /**
  * Recompute distances from origin for all elements in pt.
  */
-void ccdPtRecomputeDistances(ccd_pt_t *pt);
+CCD_EXPORT void ccdPtRecomputeDistances(ccd_pt_t *pt);
 
 /**
  * Returns nearest element to origin.
  */
-ccd_pt_el_t *ccdPtNearest(ccd_pt_t *pt);
+CCD_EXPORT ccd_pt_el_t *ccdPtNearest(ccd_pt_t *pt);
 
 
-void ccdPtDumpSVT(ccd_pt_t *pt, const char *fn);
-void ccdPtDumpSVT2(ccd_pt_t *pt, FILE *);
+CCD_EXPORT void ccdPtDumpSVT(ccd_pt_t *pt, const char *fn);
+CCD_EXPORT void ccdPtDumpSVT2(ccd_pt_t *pt, FILE *);
 
 
 /**** INLINES ****/

--- a/src/support.h
+++ b/src/support.h
@@ -37,7 +37,7 @@ _ccd_inline void ccdSupportCopy(ccd_support_t *, const ccd_support_t *s);
  * Computes support point of obj1 and obj2 in direction dir.
  * Support point is returned via supp.
  */
-void __ccdSupport(const void *obj1, const void *obj2,
+CCD_EXPORT void __ccdSupport(const void *obj1, const void *obj2,
                   const ccd_vec3_t *dir, const ccd_t *ccd,
                   ccd_support_t *supp);
 


### PR DESCRIPTION
This PR implements the [control of binary symbols visibility](https://gcc.gnu.org/wiki/Visibility) in libccd.

The PR uses the cmake `GenerateExportsHeader` to provide the needed export header and change the visibility name to `CCD_EXPORT`.

The PR also adds the `CCD_HIDE_ALL_SYMBOLS` option (OFF by the default). This option covers a use case we found in Drake where a software uses ccd (linked statically) but does not expose it in the public API (headers). In this scenario the best option to avoid any possible conflict with other versions of fcl is to hide all the symbols from the public ABI.

I've tested this PR against the current fcl mastert branch.