### PR TITLE
Export declaration incorrect for windows build

### DIFF
--- a/src/ccd/ccd_export.h
+++ b/src/ccd/ccd_export.h
@@ -6,9 +6,9 @@
 #else
 #  ifdef _MSC_VER
 #    ifdef ccd_EXPORTS
-#      define _ccd_export __declspec(dllexport)
+#      define CCD_EXPORT __declspec(dllexport)
 #   else /* ccd_EXPORTS */
-#     define _ccd_export __declspec(dllimport)
+#     define CCD_EXPORT  __declspec(dllimport)
 #   endif /* ccd_EXPORTS */
 #  else
 #    ifndef CCD_EXPORT


### PR DESCRIPTION
Under windows, rather than defining `CCD_EXPORT`, `_ccd_export` was being
defined leading to a litany of compilation errors. This corrects the
problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/danfis/libccd/40)
<!-- Reviewable:end -->
