### PR TITLE
Don't divide by zero if penetration depth is zero.

### DIFF
--- a/src/mpr.c
+++ b/src/mpr.c
@@ -328,7 +328,10 @@ static void findPenetr(const void *obj1, const void *obj2, const ccd_t *ccd,
                                           &ccdSimplexPoint(portal, 3)->v,
                                           pdir);
             *depth = CCD_SQRT(*depth);
-            ccdVec3Normalize(pdir);
+            if ( *depth > - FLT_EPSILON && *depth < FLT_EPSILON )
+                ccdVec3Set( pdir, 1,0,0 );
+            else
+                ccdVec3Normalize(pdir);
 
             // barycentric coordinates:
             findPos(obj1, obj2, ccd, portal, pos);


### PR DESCRIPTION
This fixes issue #49