### PR TITLE
list.h: rename variable to not be a C++ keyword

### DIFF
--- a/src/list.h
+++ b/src/list.h
@@ -132,12 +132,12 @@ _ccd_inline int ccdListEmpty(const ccd_list_t *head)
     return head->next == head;
 }
 
-_ccd_inline void ccdListAppend(ccd_list_t *l, ccd_list_t *new)
+_ccd_inline void ccdListAppend(ccd_list_t *l, ccd_list_t *new_list)
 {
-    new->prev = l->prev;
-    new->next = l;
-    l->prev->next = new;
-    l->prev = new;
+    new_list->prev = l->prev;
+    new_list->next = l;
+    l->prev->next = new_list;
+    l->prev = new_list;
 }
 
 _ccd_inline void ccdListDel(ccd_list_t *item)

--- a/src/list.h
+++ b/src/list.h
@@ -132,12 +132,12 @@ _ccd_inline int ccdListEmpty(const ccd_list_t *head)
     return head->next == head;
 }
 
-_ccd_inline void ccdListAppend(ccd_list_t *l, ccd_list_t *new_list)
+_ccd_inline void ccdListAppend(ccd_list_t *l, ccd_list_t *new_item)
 {
-    new_list->prev = l->prev;
-    new_list->next = l;
-    l->prev->next = new_list;
-    l->prev = new_list;
+    new_item->prev = l->prev;
+    new_item->next = l;
+    l->prev->next = new_item;
+    l->prev = new_item;
 }
 
 _ccd_inline void ccdListDel(ccd_list_t *item)


### PR DESCRIPTION
In the `list.h` header, there is a variable called `new`.  I know this is not a public header, but it is easy enough to change this variable so that the header could be included by a C++ file later on (as seems indicated by the `extern "C"` declaration at the top of the file)