### PR TITLE
testsuites/bench: fix compiler warning

### DIFF
--- a/src/testsuites/bench.c
+++ b/src/testsuites/bench.c
@@ -1,4 +1,7 @@
+#ifndef CU_ENABLE_TIMER
 #define CU_ENABLE_TIMER
+#endif
+
 #include <cu/cu.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/testsuites/bench2.c
+++ b/src/testsuites/bench2.c
@@ -1,4 +1,7 @@
+#ifndef CU_ENABLE_TIMER
 #define CU_ENABLE_TIMER
+#endif
+
 #include <cu/cu.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Compiler warns of duplicate macro definition for `CU_ENABLE_TIMER`.
This change simply surrounds it with an `ifndef`.