### PR TITLE
Fix configuration with  Emscripten

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(ccd PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Emscripten"))
   find_library(LIBM_LIBRARY NAMES m)
   if(NOT LIBM_LIBRARY)
     message(FATAL_ERROR "Could NOT find required library LibM")


### PR DESCRIPTION
In Emscripten there is no separate libm library, so there is no need to explicitly link it, 
and in particular the find_library call would fail as there is not libm to find.
See https://stackoverflow.com/questions/24663915/how-can-i-link-libm-to-my-emscripten-port