### PR TITLE
Define and propagate CCD_STATIC_DEFINE if the library is compiled as static

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,9 @@ set_target_properties(ccd PROPERTIES
 target_include_directories(ccd PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
-
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_definitions(ccd PUBLIC CCD_STATIC_DEFINE)
+endif()
 if(NOT WIN32)
   find_library(LIBM_LIBRARY NAMES m)
   if(NOT LIBM_LIBRARY)


### PR DESCRIPTION
When the ccd library is compiled as static, the `CCD_EXPORT` should be an empty string, especially on Windows, to avoid linking errors. This can be achieved easily by making sure that `CCD_STATIC_DEFINE` is defined both when buildng ccd as static, and also when the static ccd is consumed by downstream CMake libraries. 

Fix https://github.com/danfis/libccd/issues/33 .